### PR TITLE
Adding opts.root and operator precedence error

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ exports.compile = function (str, options) {
   const opts = extend({watch: false}, options)
 
   // Find the path for which the environment will be created.
-  const envpath = opts.root || opts.path || opts.filename ? path.dirname(opts.filename) : null
+  const envpath = opts.root || opts.path || (opts.filename ? path.dirname(opts.filename) : null)
   let env = null
   if (envpath) {
     env = nunjucks.configure(envpath, opts)

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ exports.compile = function (str, options) {
   const opts = extend({watch: false}, options)
 
   // Find the path for which the environment will be created.
-  const envpath = opts.path || opts.filename ? path.dirname(opts.filename) : null
+  const envpath = opts.root || opts.path || opts.filename ? path.dirname(opts.filename) : null
   let env = null
   if (envpath) {
     env = nunjucks.configure(envpath, opts)


### PR DESCRIPTION
I've been having trouble with paths being included and searching for templates. I've included the opts.root in addition to opts.path as metalsmith-jstransformer passes the root as opts.root and not opts.path - and the nunjucks documentation says "Tell nunjucks that your templates live at path"