### PR TITLE
addGlobal implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,10 +38,10 @@ exports.compile = function (str, options) {
       env.addFilter(name, filter)
     }
   }
-  
+
   // Add all the Globals.
-  for (var name in opts.globals || {}) {
-    env.addGlobal(name, opts.globals[name]);
+  for (const name in opts.globals || {}) {
+    env.addGlobal(name, opts.globals[name])
   }
 
   // Compile the template.

--- a/index.js
+++ b/index.js
@@ -38,6 +38,11 @@ exports.compile = function (str, options) {
       env.addFilter(name, filter)
     }
   }
+  
+  // Add all the Globals.
+  for (var name in opts.globals || {}) {
+    env.addGlobal(name, opts.globals[name]);
+  }
 
   // Compile the template.
   const template = nunjucks.compile(str, env, opts.filename || null, true)


### PR DESCRIPTION
Can now pass through { globals: { x: 'y' } } just like filters