### PR TITLE
Fix typo in README (extention → extension)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Many of the API methods accept an `options` dictionary object. The following opt
   or as the name of a Node module (as a string).
   If you specify a module name, that module's default export will be used as the filter function.
   
-- **`extentions`**: A set of Nunjucks extentions to add.
-  The value of `extentions` should be a dictionary object where the keys are the extention names to use in the templates.
-  The dictionary values define the extention functions, either as JavaScript function objects,
+- **`extensions`**: A set of Nunjucks extensions to add.
+  The value of `extensions` should be a dictionary object where the keys are the extension names to use in the templates.
+  The dictionary values define the extension functions, either as JavaScript function objects,
   or as the name of a Node module (as a string).
   
 - **`globals`**: A set of [global variables](https://mozilla.github.io/nunjucks/api#addglobal) available to all templates.


### PR DESCRIPTION
The plugin uses the correct spelling (extension) in the code:

https://github.com/jstransformers/jstransformer-nunjucks/blob/774e766670a3519af554c361039c93f6c1d034be/index.js#L43