### PR TITLE
feat: add support for async compiling

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,65 +3,79 @@
 const path = require('path')
 const nunjucks = require('nunjucks')
 const extend = require('extend-shallow')
+const Promise = require('promise')
 
 exports.name = 'nunjucks'
 exports.inputFormats = ['njk', 'nunjucks']
 exports.outputFormat = 'html'
 
 exports.compile = function (str, options) {
-  // Prepare the options.
-  const opts = extend({watch: false}, options)
-
-  const env = nunjucksEnv(opts)
-
-  // Add all the Filters.
-  for (const name in opts.filters || {}) {
-    if ({}.hasOwnProperty.call(opts.filters, name)) {
-      let filter = null
-      switch (typeof opts.filters[name]) {
-        case 'string':
-          filter = require(opts.filters[name])
-          break
-        case 'function':
-        default:
-          filter = opts.filters[name]
-          break
-      }
-
-      env.addFilter(name, filter)
-    }
-  }
-
-  // Add all the Extensions.
-  for (const name in opts.extensions || {}) {
-    if ({}.hasOwnProperty.call(opts.extensions, name)) {
-      let extension = null
-      switch (typeof opts.extensions[name]) {
-        case 'string':
-          extension = require(opts.extensions[name])
-          break
-        case 'function':
-        default:
-          extension = opts.extensions[name]
-          break
-      }
-
-      env.addExtension(name, extension)
-    }
-  }
-
-  // Add all the Globals.
-  for (const name in opts.globals || {}) {
-    if (opts.globals[name] !== null) {
-      env.addGlobal(name, opts.globals[name])
-    }
-  }
-
   // Compile the template.
-  const template = nunjucks.compile(str, env, opts.filename || null, true)
-
+  const template = compiledTemplate(str, options)
   // Bind the render function as the returning function.
   return template.render.bind(template)
+}
+
+exports.compileAsync = function (str, options) {
+  // Compile the template.
+  const template = compiledTemplate(str, options)
+  // Bind the render function as the returning function.
+  const boundRenderFn = template.render.bind(template)
+  // Return the render function as a promise. The callback will resolve the promise.
+  return Promise.denodeify(boundRenderFn)
+}
+
+function compiledTemplate(str, options) {
+    // Prepare the options.
+    const opts = extend({watch: false}, options)
+
+    const env = nunjucksEnv(opts)
+  
+    // Add all the Filters.
+    for (const name in opts.filters || {}) {
+      if ({}.hasOwnProperty.call(opts.filters, name)) {
+        let filter = null
+        switch (typeof opts.filters[name]) {
+          case 'string':
+            filter = require(opts.filters[name])
+            break
+          case 'function':
+          default:
+            filter = opts.filters[name]
+            break
+        }
+  
+        env.addFilter(name, filter)
+      }
+    }
+  
+    // Add all the Extensions.
+    for (const name in opts.extensions || {}) {
+      if ({}.hasOwnProperty.call(opts.extensions, name)) {
+        let extension = null
+        switch (typeof opts.extensions[name]) {
+          case 'string':
+            extension = require(opts.extensions[name])
+            break
+          case 'function':
+          default:
+            extension = opts.extensions[name]
+            break
+        }
+  
+        env.addExtension(name, extension)
+      }
+    }
+  
+    // Add all the Globals.
+    for (const name in opts.globals || {}) {
+      if (opts.globals[name] !== null) {
+        env.addGlobal(name, opts.globals[name])
+      }
+    }
+    
+    // Compile the template.
+    return nunjucks.compile(str, env, opts.filename || null, true)
 }
 
 function nunjucksEnv(opts) {

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ exports.compileAsync = function (str, options) {
   // Bind the render function as the returning function.
   const boundRenderFn = template.render.bind(template)
   // Return the render function as a promise. The callback will resolve the promise.
-  return Promise.denodeify(boundRenderFn)
+  return Promise.resolve(Promise.denodeify(boundRenderFn))
 }
 
 function compiledTemplate(str, options) {


### PR DESCRIPTION
jstransformer-nunjucks doesn't support asynchronous rendering, but nunjucks does, as explained in issue #35.

The basic jstransformer library looks for `compileAsync`, just before it defaults to the `compile` method as a final resort when `compileFileAsync` is called. This PR implement `compileAsync`

Nunjucks uses callbacks for asynchronous support, but jstransformer expects promises. Therefor the render function is denodified, which means that the render functions is wrapped in a promise, and the callback resolves the promise. 

